### PR TITLE
Add wrapper package for context-based response handling

### DIFF
--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -1,0 +1,230 @@
+// Package wrapper provides context-based response handling for Chi middleware.
+//
+// The wrapper pattern allows handlers and middleware to set responses and errors
+// in request context rather than writing directly to ResponseWriter. This enables:
+//   - Consistent JSON error responses across all middleware
+//   - Stripe-style structured errors with type, code, message, and field errors
+//   - Response interception and modification by outer middleware
+//   - Panic recovery with safe error responses
+//
+// Basic usage:
+//
+//	r := chi.NewRouter()
+//	r.Use(wrapper.Handler())  // Outermost middleware
+//
+//	r.Post("/users", func(w http.ResponseWriter, r *http.Request) {
+//	    user, err := createUser(req)
+//	    if err != nil {
+//	        wrapper.SetError(r, wrapper.ErrInternal)
+//	        return
+//	    }
+//	    wrapper.SetResponse(r, http.StatusCreated, user)
+//	})
+package wrapper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+)
+
+type contextKey string
+
+const stateKey contextKey = "wrapper_state"
+
+// State holds the response state for a request.
+type State struct {
+	mu      sync.Mutex
+	err     *Error
+	status  int
+	body    any
+	headers http.Header
+}
+
+// Error represents a structured API error response.
+type Error struct {
+	Type    string       `json:"type"`
+	Code    string       `json:"code,omitempty"`
+	Message string       `json:"message"`
+	Param   string       `json:"param,omitempty"`
+	Errors  []FieldError `json:"errors,omitempty"`
+	Status  int          `json:"-"`
+}
+
+// FieldError represents a validation error for a specific field.
+type FieldError struct {
+	Field   string `json:"field"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return e.Message
+}
+
+// Is implements errors.Is for comparing error types.
+func (e *Error) Is(target error) bool {
+	t, ok := target.(*Error)
+	if !ok {
+		return false
+	}
+	return e.Type == t.Type && e.Code == t.Code
+}
+
+// With returns a copy of the error with a custom message.
+func (e *Error) With(message string) *Error {
+	dup := *e
+	dup.Message = message
+	return &dup
+}
+
+// WithParam returns a copy of the error with a custom message and parameter.
+func (e *Error) WithParam(message, param string) *Error {
+	dup := *e
+	dup.Message = message
+	dup.Param = param
+	return &dup
+}
+
+// Predefined sentinel errors
+var (
+	ErrBadRequest          = &Error{Type: "request_error", Code: "bad_request", Message: "Bad request", Status: http.StatusBadRequest}
+	ErrUnauthorized        = &Error{Type: "auth_error", Code: "unauthorized", Message: "Unauthorized", Status: http.StatusUnauthorized}
+	ErrPaymentRequired     = &Error{Type: "request_error", Code: "payment_required", Message: "Payment required", Status: http.StatusPaymentRequired}
+	ErrForbidden           = &Error{Type: "auth_error", Code: "forbidden", Message: "Forbidden", Status: http.StatusForbidden}
+	ErrNotFound            = &Error{Type: "not_found", Code: "resource_not_found", Message: "Resource not found", Status: http.StatusNotFound}
+	ErrMethodNotAllowed    = &Error{Type: "request_error", Code: "method_not_allowed", Message: "Method not allowed", Status: http.StatusMethodNotAllowed}
+	ErrConflict            = &Error{Type: "request_error", Code: "conflict", Message: "Conflict", Status: http.StatusConflict}
+	ErrGone                = &Error{Type: "request_error", Code: "gone", Message: "Resource gone", Status: http.StatusGone}
+	ErrPayloadTooLarge     = &Error{Type: "request_error", Code: "payload_too_large", Message: "Payload too large", Status: http.StatusRequestEntityTooLarge}
+	ErrUnprocessableEntity = &Error{Type: "validation_error", Code: "unprocessable", Message: "Unprocessable entity", Status: http.StatusUnprocessableEntity}
+	ErrRateLimited         = &Error{Type: "rate_limit_error", Code: "limit_exceeded", Message: "Rate limit exceeded", Status: http.StatusTooManyRequests}
+	ErrInternal            = &Error{Type: "internal_error", Code: "internal", Message: "Internal server error", Status: http.StatusInternalServerError}
+	ErrNotImplemented      = &Error{Type: "request_error", Code: "not_implemented", Message: "Not implemented", Status: http.StatusNotImplemented}
+	ErrServiceUnavailable  = &Error{Type: "request_error", Code: "service_unavailable", Message: "Service unavailable", Status: http.StatusServiceUnavailable}
+)
+
+// NewValidationError creates a validation error with multiple field errors.
+func NewValidationError(errors []FieldError) *Error {
+	return &Error{
+		Type:    "validation_error",
+		Code:    "invalid_request",
+		Message: "Validation failed",
+		Errors:  errors,
+		Status:  http.StatusBadRequest,
+	}
+}
+
+// SetError sets an error response in the request context.
+func SetError(r *http.Request, err *Error) {
+	state := getState(r.Context())
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.err = err
+}
+
+// SetResponse sets a success response in the request context.
+func SetResponse(r *http.Request, status int, body any) {
+	state := getState(r.Context())
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.status = status
+	state.body = body
+}
+
+// SetHeader sets a response header in the request context.
+func SetHeader(r *http.Request, key, value string) {
+	state := getState(r.Context())
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.headers == nil {
+		state.headers = make(http.Header)
+	}
+	state.headers.Set(key, value)
+}
+
+// AddHeader adds a response header value in the request context.
+func AddHeader(r *http.Request, key, value string) {
+	state := getState(r.Context())
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.headers == nil {
+		state.headers = make(http.Header)
+	}
+	state.headers.Add(key, value)
+}
+
+// HasState returns true if wrapper state exists in the context.
+func HasState(ctx context.Context) bool {
+	return getState(ctx) != nil
+}
+
+func getState(ctx context.Context) *State {
+	state, _ := ctx.Value(stateKey).(*State)
+	return state
+}
+
+// Handler returns middleware that manages response state and writes responses.
+func Handler() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			state := &State{}
+			ctx := context.WithValue(r.Context(), stateKey, state)
+			r = r.WithContext(ctx)
+
+			defer func() {
+				if rec := recover(); rec != nil {
+					state.mu.Lock()
+					state.err = ErrInternal
+					state.mu.Unlock()
+				}
+				writeResponse(w, state)
+			}()
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func writeResponse(w http.ResponseWriter, state *State) {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	for key, values := range state.headers {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	if state.err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(state.err.Status)
+		json.NewEncoder(w).Encode(map[string]*Error{"error": state.err})
+		return
+	}
+
+	if state.body != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(state.status)
+		json.NewEncoder(w).Encode(state.body)
+		return
+	}
+
+	if state.status != 0 {
+		w.WriteHeader(state.status)
+	}
+}

--- a/wrapper/wrapper_test.go
+++ b/wrapper/wrapper_test.go
@@ -1,0 +1,333 @@
+package wrapper
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandler_SuccessResponse(t *testing.T) {
+	handler := Handler()(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		SetResponse(r, http.StatusCreated, map[string]string{"id": "123"})
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("expected status %d, got %d", http.StatusCreated, rec.Code)
+	}
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", ct)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body["id"] != "123" {
+		t.Errorf("expected id=123, got %s", body["id"])
+	}
+}
+
+func TestHandler_ErrorResponse(t *testing.T) {
+	handler := Handler()(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		SetError(r, ErrNotFound.With("User not found"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+	}
+
+	var body map[string]*Error
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	errResp := body["error"]
+	if errResp.Type != "not_found" {
+		t.Errorf("expected type not_found, got %s", errResp.Type)
+	}
+	if errResp.Message != "User not found" {
+		t.Errorf("expected message 'User not found', got %s", errResp.Message)
+	}
+}
+
+func TestHandler_ErrorTakesPrecedence(t *testing.T) {
+	handler := Handler()(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		SetResponse(r, http.StatusOK, map[string]string{"status": "ok"})
+		SetError(r, ErrUnauthorized)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+}
+
+func TestHandler_PanicRecovery(t *testing.T) {
+	handler := Handler()(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("something went wrong")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, rec.Code)
+	}
+
+	var body map[string]*Error
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body["error"].Type != "internal_error" {
+		t.Errorf("expected type internal_error, got %s", body["error"].Type)
+	}
+}
+
+func TestHandler_CustomHeaders(t *testing.T) {
+	handler := Handler()(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		SetHeader(r, "X-Request-ID", "abc123")
+		SetHeader(r, "X-RateLimit-Remaining", "99")
+		SetResponse(r, http.StatusOK, map[string]string{"status": "ok"})
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Header().Get("X-Request-ID") != "abc123" {
+		t.Errorf("expected X-Request-ID=abc123, got %s", rec.Header().Get("X-Request-ID"))
+	}
+	if rec.Header().Get("X-RateLimit-Remaining") != "99" {
+		t.Errorf("expected X-RateLimit-Remaining=99, got %s", rec.Header().Get("X-RateLimit-Remaining"))
+	}
+}
+
+func TestHandler_EmptyResponse(t *testing.T) {
+	handler := Handler()(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		// No SetResponse or SetError called
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestHandler_StatusOnlyResponse(t *testing.T) {
+	handler := Handler()(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		SetResponse(r, http.StatusNoContent, nil)
+	}))
+
+	req := httptest.NewRequest(http.MethodDelete, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected status %d, got %d", http.StatusNoContent, rec.Code)
+	}
+}
+
+func TestHasState(t *testing.T) {
+	var hasStateInHandler bool
+
+	handler := Handler()(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		hasStateInHandler = HasState(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if !hasStateInHandler {
+		t.Error("expected HasState to return true inside Handler")
+	}
+
+	// Without wrapper
+	req2 := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	if HasState(req2.Context()) {
+		t.Error("expected HasState to return false without Handler")
+	}
+}
+
+func TestError_With(t *testing.T) {
+	err := ErrNotFound.With("Custom message")
+
+	if err.Message != "Custom message" {
+		t.Errorf("expected message 'Custom message', got %s", err.Message)
+	}
+	if err.Type != ErrNotFound.Type {
+		t.Errorf("expected type %s, got %s", ErrNotFound.Type, err.Type)
+	}
+	if err.Code != ErrNotFound.Code {
+		t.Errorf("expected code %s, got %s", ErrNotFound.Code, err.Code)
+	}
+	if err.Status != ErrNotFound.Status {
+		t.Errorf("expected status %d, got %d", ErrNotFound.Status, err.Status)
+	}
+
+	// Original unchanged
+	if ErrNotFound.Message != "Resource not found" {
+		t.Error("original sentinel was modified")
+	}
+}
+
+func TestError_WithParam(t *testing.T) {
+	err := ErrBadRequest.WithParam("Invalid email format", "email")
+
+	if err.Message != "Invalid email format" {
+		t.Errorf("expected message 'Invalid email format', got %s", err.Message)
+	}
+	if err.Param != "email" {
+		t.Errorf("expected param 'email', got %s", err.Param)
+	}
+}
+
+func TestError_Is(t *testing.T) {
+	err := ErrNotFound.With("User not found")
+
+	if !errors.Is(err, ErrNotFound) {
+		t.Error("expected errors.Is to match ErrNotFound")
+	}
+
+	if errors.Is(err, ErrUnauthorized) {
+		t.Error("expected errors.Is not to match ErrUnauthorized")
+	}
+}
+
+func TestNewValidationError(t *testing.T) {
+	fieldErrors := []FieldError{
+		{Field: "email", Code: "required", Message: "Email is required"},
+		{Field: "age", Code: "min", Message: "Age must be at least 18"},
+	}
+
+	err := NewValidationError(fieldErrors)
+
+	if err.Type != "validation_error" {
+		t.Errorf("expected type validation_error, got %s", err.Type)
+	}
+	if err.Code != "invalid_request" {
+		t.Errorf("expected code invalid_request, got %s", err.Code)
+	}
+	if len(err.Errors) != 2 {
+		t.Errorf("expected 2 field errors, got %d", len(err.Errors))
+	}
+	if err.Status != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, err.Status)
+	}
+}
+
+func TestValidationError_JSONFormat(t *testing.T) {
+	handler := Handler()(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		SetError(r, NewValidationError([]FieldError{
+			{Field: "email", Code: "required", Message: "Email is required"},
+		}))
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	var body struct {
+		Error struct {
+			Type    string       `json:"type"`
+			Code    string       `json:"code"`
+			Message string       `json:"message"`
+			Errors  []FieldError `json:"errors"`
+		} `json:"error"`
+	}
+
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body.Error.Type != "validation_error" {
+		t.Errorf("expected type validation_error, got %s", body.Error.Type)
+	}
+	if len(body.Error.Errors) != 1 {
+		t.Errorf("expected 1 field error, got %d", len(body.Error.Errors))
+	}
+	if body.Error.Errors[0].Field != "email" {
+		t.Errorf("expected field 'email', got %s", body.Error.Errors[0].Field)
+	}
+}
+
+func TestAddHeader(t *testing.T) {
+	handler := Handler()(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		AddHeader(r, "X-Custom", "value1")
+		AddHeader(r, "X-Custom", "value2")
+		SetResponse(r, http.StatusOK, nil)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	values := rec.Header().Values("X-Custom")
+	if len(values) != 2 {
+		t.Errorf("expected 2 header values, got %d", len(values))
+	}
+}
+
+func TestAllSentinelErrors(t *testing.T) {
+	sentinels := []*Error{
+		ErrBadRequest,
+		ErrUnauthorized,
+		ErrPaymentRequired,
+		ErrForbidden,
+		ErrNotFound,
+		ErrMethodNotAllowed,
+		ErrConflict,
+		ErrGone,
+		ErrPayloadTooLarge,
+		ErrUnprocessableEntity,
+		ErrRateLimited,
+		ErrInternal,
+		ErrNotImplemented,
+		ErrServiceUnavailable,
+	}
+
+	for _, sentinel := range sentinels {
+		if sentinel.Type == "" {
+			t.Errorf("sentinel %s has empty Type", sentinel.Code)
+		}
+		if sentinel.Code == "" {
+			t.Errorf("sentinel with Type %s has empty Code", sentinel.Type)
+		}
+		if sentinel.Message == "" {
+			t.Errorf("sentinel %s has empty Message", sentinel.Code)
+		}
+		if sentinel.Status == 0 {
+			t.Errorf("sentinel %s has zero Status", sentinel.Code)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `wrapper` package for context-based response handling with Stripe-style structured errors
- Context-based SetError/SetResponse/SetHeader functions
- Handler middleware that writes responses from context
- Predefined sentinel errors with With/WithParam methods
- HasState for dual-mode middleware support
- Panic recovery with safe error response

Closes #3