### PR TITLE
Refactor ratelimit to functional options pattern

### DIFF
--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,25 +1,27 @@
 // Package ratelimit provides flexible rate limiting middleware for Chi and standard http.Handler.
 //
-// The package offers two API styles: a simple API for common use cases (ByIP, ByHeader, etc.)
-// and a fluent Builder API for complex multi-dimensional rate limiting scenarios. All middleware
-// sets standard rate limit headers (RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset) and
-// returns 429 (Too Many Requests) when limits are exceeded.
+// The package uses a functional options pattern for configuring rate limiters. Key dimensions
+// (IP, header, endpoint, etc.) are added via options, allowing single or multi-dimensional
+// rate limiting. All middleware sets standard rate limit headers (RateLimit-Limit,
+// RateLimit-Remaining, RateLimit-Reset) and returns 429 (Too Many Requests) when limits
+// are exceeded.
 //
-// Simple API example:
+// Single dimension example:
 //
 //	store := store.NewMemory()
 //	defer store.Close()
-//	r.Use(ratelimit.ByIP(store, 100, time.Minute))
+//	r.Use(ratelimit.New(store, 100, 1*time.Minute, ratelimit.WithIP()).Handler)
 //
-// Advanced multi-dimensional example:
+// Multi-dimensional example:
 //
-//	limiter := ratelimit.NewBuilder(store).
-//		WithIP().
-//		WithHeader("X-Tenant-ID").
-//		Limit(100, time.Minute)
-//	r.Use(limiter)
+//	limiter := ratelimit.New(store, 100, 1*time.Minute,
+//	    ratelimit.WithName("api"),
+//	    ratelimit.WithIP(),
+//	    ratelimit.WithHeader("X-Tenant-ID"),
+//	)
+//	r.Use(limiter.Handler)
 //
-// Rate limiting is automatically skipped when the key function returns an empty string.
+// Rate limiting is automatically skipped when no key dimensions produce a value.
 // For distributed deployments (Kubernetes), use the Redis store. The in-memory store
 // is only suitable for single-instance deployments and development.
 package ratelimit
@@ -36,7 +38,6 @@ import (
 )
 
 // HeaderMode controls when rate limit headers are included in responses.
-// This configuration is only available through the Builder API.
 type HeaderMode int
 
 const (
@@ -63,7 +64,8 @@ type Limiter struct {
 	store      store.Store
 	limit      int64
 	window     time.Duration
-	keyFn      KeyFunc
+	name       string
+	keyFns     []KeyFunc
 	headerMode HeaderMode
 }
 
@@ -77,26 +79,129 @@ func WithHeaderMode(mode HeaderMode) Option {
 	}
 }
 
+// WithName sets a prefix for rate limit keys.
+// Use to prevent key collisions when layering multiple rate limiters.
+func WithName(name string) Option {
+	return func(l *Limiter) {
+		l.name = name
+	}
+}
+
+// WithIP adds the client IP address (from RemoteAddr) to the rate limiting key.
+// Use this for direct connections without a proxy.
+func WithIP() Option {
+	return func(l *Limiter) {
+		l.keyFns = append(l.keyFns, func(r *http.Request) string {
+			ip, _, err := net.SplitHostPort(r.RemoteAddr)
+			if err != nil {
+				return r.RemoteAddr
+			}
+			return ip
+		})
+	}
+}
+
+// WithRealIP adds the client IP from X-Forwarded-For or X-Real-IP headers.
+// Use this when behind a proxy/load balancer. Returns empty string if neither
+// header is present (rate limiting will be skipped).
+//
+// SECURITY: Only use this behind a trusted reverse proxy that sets these headers.
+// Without a proxy, clients can spoof X-Forwarded-For to bypass rate limits.
+func WithRealIP() Option {
+	return func(l *Limiter) {
+		l.keyFns = append(l.keyFns, func(r *http.Request) string {
+			if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+				if idx := strings.Index(xff, ","); idx != -1 {
+					return strings.TrimSpace(xff[:idx])
+				}
+				return strings.TrimSpace(xff)
+			}
+			if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+				return strings.TrimSpace(realIP)
+			}
+			return ""
+		})
+	}
+}
+
+// WithEndpoint adds the HTTP method and path to the rate limiting key.
+// Key component format: "<method>:<path>"
+func WithEndpoint() Option {
+	return func(l *Limiter) {
+		l.keyFns = append(l.keyFns, func(r *http.Request) string {
+			var sb strings.Builder
+			sb.Grow(len(r.Method) + 1 + len(r.URL.Path))
+			sb.WriteString(r.Method)
+			sb.WriteByte(':')
+			sb.WriteString(r.URL.Path)
+			return sb.String()
+		})
+	}
+}
+
+// WithHeader adds a header value to the rate limiting key.
+// If the header is missing, returns empty string (rate limiting skipped).
+func WithHeader(header string) Option {
+	return func(l *Limiter) {
+		l.keyFns = append(l.keyFns, func(r *http.Request) string {
+			return r.Header.Get(header)
+		})
+	}
+}
+
+// WithQueryParam adds a query parameter value to the rate limiting key.
+// If the parameter is missing, returns empty string (rate limiting skipped).
+func WithQueryParam(param string) Option {
+	return func(l *Limiter) {
+		l.keyFns = append(l.keyFns, func(r *http.Request) string {
+			return r.URL.Query().Get(param)
+		})
+	}
+}
+
+// WithCustomKey adds a custom key function to the rate limiting key.
+// Return empty string to skip rate limiting for a request.
+func WithCustomKey(fn KeyFunc) Option {
+	return func(l *Limiter) {
+		l.keyFns = append(l.keyFns, fn)
+	}
+}
+
 // New creates a new rate limiter with the given store, limit, and window.
-// The keyFn determines what to rate limit by (IP, header, etc.).
+// Use With* options to configure key dimensions and behavior.
 // Returns 429 (Too Many Requests) when the limit is exceeded, with standard
 // rate limit headers and a Retry-After header indicating seconds until reset.
 // Returns 500 (Internal Server Error) if the store operation fails.
 //
-// If keyFn returns an empty string, rate limiting is skipped for that request.
+// At least one key dimension option (WithIP, WithRealIP, WithHeader, WithEndpoint,
+// WithQueryParam, or WithCustomKey) must be provided. Panics if no key dimensions
+// are configured.
+//
+// If no key dimensions produce a value at runtime (e.g., missing header),
+// rate limiting is skipped for that request.
 //
 // Options:
+//   - WithIP: Add RemoteAddr IP to key (direct connections)
+//   - WithRealIP: Add X-Forwarded-For/X-Real-IP to key (proxied requests, skips if missing)
+//   - WithEndpoint: Add method:path to key
+//   - WithHeader: Add header value to key (skips if missing)
+//   - WithQueryParam: Add query parameter to key (skips if missing)
+//   - WithCustomKey: Add custom key function
+//   - WithName: Set key prefix for collision prevention
 //   - WithHeaderMode: Configure header visibility (default: HeadersAlways)
-func New(st store.Store, limit int, window time.Duration, keyFn KeyFunc, opts ...Option) *Limiter {
+func New(st store.Store, limit int, window time.Duration, opts ...Option) *Limiter {
 	l := &Limiter{
 		store:      st,
 		limit:      int64(limit),
 		window:     window,
-		keyFn:      keyFn,
+		keyFns:     make([]KeyFunc, 0),
 		headerMode: HeadersAlways,
 	}
 	for _, opt := range opts {
 		opt(l)
+	}
+	if len(l.keyFns) == 0 {
+		panic("ratelimit: must configure at least one key dimension option (WithIP, WithRealIP, WithEndpoint, WithHeader, WithQueryParam, or WithCustomKey)")
 	}
 	return l
 }
@@ -111,7 +216,7 @@ func New(st store.Store, limit int, window time.Duration, keyFn KeyFunc, opts ..
 // These headers follow the IETF draft-ietf-httpapi-ratelimit-headers specification.
 func (l *Limiter) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		key := l.keyFn(r)
+		key := l.buildKey(r)
 		if key == "" {
 			next.ServeHTTP(w, r)
 			return
@@ -168,250 +273,28 @@ func (l *Limiter) Handler(next http.Handler) http.Handler {
 	})
 }
 
-// ByIP creates IP-based rate limiting middleware.
-// Uses the RemoteAddr from the request to determine the client IP.
-// The generated key format is "ip:<address>".
-//
-// Example:
-//
-//	store := store.NewMemory()
-//	r.Use(ratelimit.ByIP(store, 100, time.Minute)) // 100 requests per minute per IP
-func ByIP(st store.Store, limit int, window time.Duration) func(http.Handler) http.Handler {
-	limiter := New(st, limit, window, func(r *http.Request) string {
-		ip, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			ip = r.RemoteAddr
-		}
-		var b strings.Builder
-		b.Grow(3 + len(ip))
-		b.WriteString("ip:")
-		b.WriteString(ip)
-		return b.String()
-	})
-	return limiter.Handler
-}
+func (l *Limiter) buildKey(r *http.Request) string {
+	var sb strings.Builder
+	sb.Grow(20 + len(l.keyFns)*30)
+	hasContent := false
 
-// ByHeader creates header-based rate limiting middleware.
-// If the specified header is missing, rate limiting is skipped for that request.
-// The generated key format is "header:<name>:<value>".
-//
-// Example:
-//
-//	r.Use(ratelimit.ByHeader(store, "X-API-Key", 1000, time.Hour))
-func ByHeader(st store.Store, header string, limit int, window time.Duration) func(http.Handler) http.Handler {
-	limiter := New(st, limit, window, func(r *http.Request) string {
-		val := r.Header.Get(header)
-		if val == "" {
-			return ""
-		}
-		var b strings.Builder
-		b.Grow(7 + len(header) + 1 + len(val))
-		b.WriteString("header:")
-		b.WriteString(header)
-		b.WriteByte(':')
-		b.WriteString(val)
-		return b.String()
-	})
-	return limiter.Handler
-}
-
-// ByEndpoint creates endpoint-based rate limiting middleware.
-// Combines the HTTP method and URL path to create a unique key per endpoint.
-// The generated key format is "endpoint:<method>:<path>".
-//
-// Example:
-//
-//	r.Use(ratelimit.ByEndpoint(store, 50, time.Minute)) // 50 req/min per endpoint
-func ByEndpoint(st store.Store, limit int, window time.Duration) func(http.Handler) http.Handler {
-	limiter := New(st, limit, window, func(r *http.Request) string {
-		var b strings.Builder
-		b.Grow(9 + len(r.Method) + 1 + len(r.URL.Path))
-		b.WriteString("endpoint:")
-		b.WriteString(r.Method)
-		b.WriteByte(':')
-		b.WriteString(r.URL.Path)
-		return b.String()
-	})
-	return limiter.Handler
-}
-
-// ByQueryParam creates query parameter-based rate limiting middleware.
-// If the specified query parameter is missing, rate limiting is skipped for that request.
-// The generated key format is "query:<param>:<value>".
-//
-// Example:
-//
-//	r.Use(ratelimit.ByQueryParam(store, "api_key", 500, time.Hour))
-func ByQueryParam(st store.Store, param string, limit int, window time.Duration) func(http.Handler) http.Handler {
-	limiter := New(st, limit, window, func(r *http.Request) string {
-		val := r.URL.Query().Get(param)
-		if val == "" {
-			return ""
-		}
-		var b strings.Builder
-		b.Grow(6 + len(param) + 1 + len(val))
-		b.WriteString("query:")
-		b.WriteString(param)
-		b.WriteByte(':')
-		b.WriteString(val)
-		return b.String()
-	})
-	return limiter.Handler
-}
-
-// Builder provides a fluent API for building complex multi-dimensional rate limiters.
-// Each With* method adds a dimension to the rate limiting key. All dimensions are
-// combined with ":" as a separator. If any dimension returns an empty string,
-// rate limiting is skipped for that request.
-//
-// Example:
-//
-//	limiter := ratelimit.NewBuilder(store).
-//		WithIP().
-//		WithHeader("X-Tenant-ID").
-//		WithEndpoint().
-//		Limit(100, time.Minute)
-//	r.Use(limiter)
-//
-// This creates a composite key like "192.168.1.1:tenant-abc:GET:/api/users"
-// allowing fine-grained rate limiting per IP, tenant, and endpoint combination.
-type Builder struct {
-	store      store.Store
-	name       string
-	limit      int
-	window     time.Duration
-	keyFns     []KeyFunc
-	headerMode HeaderMode
-}
-
-// NewBuilder creates a new rate limiter builder.
-// Use With* methods to add dimensions, then call Limit to build the middleware.
-func NewBuilder(st store.Store) *Builder {
-	return &Builder{
-		store:      st,
-		keyFns:     make([]KeyFunc, 0),
-		headerMode: HeadersAlways,
+	if l.name != "" {
+		sb.WriteString(l.name)
+		hasContent = true
 	}
-}
 
-// WithName sets an identifier for this rate limiter, prepended to all keys.
-// Use to prevent key collisions when layering multiple rate limiters.
-func (b *Builder) WithName(name string) *Builder {
-	b.name = name
-	return b
-}
-
-// WithIP adds IP address to the rate limiting key.
-// Extracts the IP from RemoteAddr, removing the port if present.
-func (b *Builder) WithIP() *Builder {
-	b.keyFns = append(b.keyFns, func(r *http.Request) string {
-		ip, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			return r.RemoteAddr
-		}
-		return ip
-	})
-	return b
-}
-
-// WithEndpoint adds endpoint (method + path) to the rate limiting key.
-// The key component format is "<method>:<path>".
-func (b *Builder) WithEndpoint() *Builder {
-	b.keyFns = append(b.keyFns, func(r *http.Request) string {
-		var sb strings.Builder
-		sb.Grow(len(r.Method) + 1 + len(r.URL.Path))
-		sb.WriteString(r.Method)
-		sb.WriteByte(':')
-		sb.WriteString(r.URL.Path)
-		return sb.String()
-	})
-	return b
-}
-
-// WithHeader adds a header value to the rate limiting key.
-// If the header is missing, returns an empty string which causes
-// rate limiting to be skipped for that request.
-func (b *Builder) WithHeader(header string) *Builder {
-	b.keyFns = append(b.keyFns, func(r *http.Request) string {
-		return r.Header.Get(header)
-	})
-	return b
-}
-
-// WithQueryParam adds a query parameter value to the rate limiting key.
-// If the parameter is missing, returns an empty string which causes
-// rate limiting to be skipped for that request.
-func (b *Builder) WithQueryParam(param string) *Builder {
-	b.keyFns = append(b.keyFns, func(r *http.Request) string {
-		return r.URL.Query().Get(param)
-	})
-	return b
-}
-
-// WithCustomKey adds a custom key function to the rate limiting key.
-// The function should return an empty string to skip rate limiting for a request.
-// Useful for custom extraction logic or computed values.
-func (b *Builder) WithCustomKey(fn KeyFunc) *Builder {
-	b.keyFns = append(b.keyFns, fn)
-	return b
-}
-
-// WithHeaderMode configures when rate limit headers are included in responses.
-// This follows the IETF draft-ietf-httpapi-ratelimit-headers specification.
-//
-// Available modes:
-//   - HeadersAlways: Include headers on all responses (default)
-//   - HeadersOnLimitExceeded: Include headers only on 429 responses
-//   - HeadersNever: Never include headers
-//
-// Example:
-//
-//	limiter := ratelimit.NewBuilder(store).
-//		WithIP().
-//		WithHeaderMode(ratelimit.HeadersOnLimitExceeded).
-//		Limit(100, time.Minute)
-func (b *Builder) WithHeaderMode(mode HeaderMode) *Builder {
-	b.headerMode = mode
-	return b
-}
-
-// Limit sets the rate limit and window, returning the middleware handler.
-// All configured dimensions are combined into a single key using ":" as a separator.
-// If any dimension returns an empty string, rate limiting is skipped for that request.
-//
-// Parameters:
-//   - limit: Maximum number of requests allowed in the time window
-//   - window: Duration of the time window (e.g., time.Minute, time.Hour)
-func (b *Builder) Limit(limit int, window time.Duration) func(http.Handler) http.Handler {
-	b.limit = limit
-	b.window = window
-
-	keyFn := func(r *http.Request) string {
-		var sb strings.Builder
-		sb.Grow(20 + len(b.keyFns)*30)
-		hasContent := false
-
-		if b.name != "" {
-			sb.WriteString(b.name)
+	for _, fn := range l.keyFns {
+		if part := fn(r); part != "" {
+			if hasContent {
+				sb.WriteByte(':')
+			}
+			sb.WriteString(part)
 			hasContent = true
 		}
-
-		for _, fn := range b.keyFns {
-			if part := fn(r); part != "" {
-				if hasContent {
-					sb.WriteByte(':')
-				}
-				sb.WriteString(part)
-				hasContent = true
-			}
-		}
-
-		if !hasContent {
-			return ""
-		}
-		return sb.String()
 	}
 
-	limiter := New(b.store, limit, window, keyFn, WithHeaderMode(b.headerMode))
-	return limiter.Handler
+	if !hasContent {
+		return ""
+	}
+	return sb.String()
 }


### PR DESCRIPTION
## Summary
- Removes Builder pattern and simple helpers (`ByIP`, `ByHeader`, `ByEndpoint`, `ByQueryParam`)
- Uses functional options only: `WithIP`, `WithRealIP`, `WithEndpoint`, `WithHeader`, `WithQueryParam`, `WithCustomKey`
- Adds `WithRealIP()` for proxied requests (X-Forwarded-For/X-Real-IP) with security warning
- Adds panic validation if no key dimensions configured (prevents silent no-op)
- Updates all tests and README documentation

## Breaking Changes
- `NewBuilder()` removed
- `New()` signature changes (no more `keyFn` positional param)
- `ByIP()`, `ByHeader()`, `ByEndpoint()`, `ByQueryParam()` removed

## Test plan
- [x] All existing tests updated for new API
- [x] Added `TestNoKeyDimensions_Panics` for panic validation
- [x] Added `TestWithRealIP_EdgeCases` for X-Forwarded-For parsing
- [x] Added `TestWithWrapper_RateLimited` for wrapper integration
- [x] Race detection passes (`go test -race`)
- [x] Linter passes (`golangci-lint run`)

Closes #13