### PR TITLE
Update canonlog to v0.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-playground/validator/v10 v10.30.1
-	github.com/nhalm/canonlog v0.3.0
+	github.com/nhalm/canonlog v0.3.1
 	github.com/redis/go-redis/v9 v9.16.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/go-playground/validator/v10 v10.30.1 h1:f3zDSN/zOma+w6+1Wswgd9fLkdwy0
 github.com/go-playground/validator/v10 v10.30.1/go.mod h1:oSuBIQzuJxL//3MelwSLD5hc2Tu889bF0Idm9Dg26cM=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
-github.com/nhalm/canonlog v0.3.0 h1:rLEqLPiFUytJft7B0WjG7WbK6wA0F+yDqfv+Gu4isGs=
-github.com/nhalm/canonlog v0.3.0/go.mod h1:Vt2KV5J+QrDW0VLREgtVNI3BuFPonDAjcXKxujHIMaA=
+github.com/nhalm/canonlog v0.3.1 h1:qqWWJssaRVF4R/IXeGqJUjF9T05YKCPhCbAV/FvWu44=
+github.com/nhalm/canonlog v0.3.1/go.mod h1:Vt2KV5J+QrDW0VLREgtVNI3BuFPonDAjcXKxujHIMaA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.16.0 h1:OotgqgLSRCmzfqChbQyG1PHC3tLNR89DG4jdOERSEP4=


### PR DESCRIPTION
## Summary
- Update canonlog dependency from v0.3.0 to v0.3.1

Closes #21

## Test plan
- [x] Tests pass