### PR TITLE
Replace deprecated actions/create-release with gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,12 +61,9 @@ jobs:
           fi
 
       - name: Create Release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.VERSION }}
-          release_name: ${{ steps.version.outputs.VERSION }}
-          body: ${{ steps.notes.outputs.NOTES }}
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ steps.version.outputs.VERSION }} \
+            --title "${{ steps.version.outputs.VERSION }}" \
+            --notes "${{ steps.notes.outputs.NOTES }}"


### PR DESCRIPTION
## Summary
- Replace archived `actions/create-release@v1` with `gh release create`
- Eliminates deprecated `set-output` warnings

Closes #23

## Test plan
- [ ] Merge and create a new tag to verify release workflow works